### PR TITLE
Initial working prototype for issuer

### DIFF
--- a/jenkins/issuer/comments
+++ b/jenkins/issuer/comments
@@ -1,0 +1,8 @@
+A python program reads the status of the playbook execution in /tmp/<YYYY-MM-DD-unique-run-id>/status file and creates a new comment at the issue github.com/openebs/e2e-results/issues/<unique-test-case-id>. The update structure would be something like:
+
+Test run update from test.openebs.io
+Test Plan id : YYYY-MM-DD-unique-run-id-AWS
+Test case id : 1234
+Ran for : 2 minutes
+Status : Success
+Logs : logs-e2e.openebs.io/<elastic link > 

--- a/jenkins/issuer/issuer.py
+++ b/jenkins/issuer/issuer.py
@@ -1,0 +1,36 @@
+import argparse,github
+
+def get_credentials(fileName):
+    file=open(fileName,"r")
+    username=file.readline()
+    password=file.readline()
+    file.close()
+    return username.strip(),password.strip()
+
+def get_comment(fileName):
+    file=open(fileName,"r")
+    comment=file.read()
+    file.close()
+    return comment.strip()
+
+def post_comment(repoName,issueNumber,username,password,comment):
+    g=github.Github(username,password)
+    print(g.get_user().get_repo(repoName).get_issue(issueNumber).create_comment(comment))
+
+def main():
+    parser = argparse.ArgumentParser(description='Issuer cli used to comment on github issues')
+    parser.add_argument('-crf', '--credential', help='Credential file contains authentication information for github api', required=True)
+    parser.add_argument('-rn', '--reponame' ,help='Repository name' ,required=True)
+    parser.add_argument('-in', '--issuenumber' ,help='Issue Number to be commented' , type=int, required=True)
+    parser.add_argument('-cof', '--comment', help='Comment file contains comment to posted on github issue',required=True)
+    args = vars(parser.parse_args())
+    username,password=get_credentials(fileName=args['credential'])
+    comment=get_comment(fileName=args['comment'])
+    reponame=args['reponame']
+    issuenumber=args['issuenumber']
+    post_comment(reponame,issuenumber,username,password,comment)
+
+
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
This PR adds a working prototype for the issuer.
-> Issuer reads credentials from the credential file and comments from the comments file which can be provided as the command line argument to the python program.
-> The issuer program has following flags for providing arguments.

           Flag name                Shorthand                                     Argument Objective
     1.  --credentials                -crf                    For providing the path of the credential file to the program.
     2.  --comment                    -cof                    For providing the path of the comment file to the program.
     3.  --reponame                   -rn                     For providing the repository name containing the issue.
     4.  --issuenumber                -in                     For providing the issue number to be commented.


->This prototype has been tested on the following [repository](https://github.com/ashishranjan738/issuer_test).
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>