### PR TITLE
Add Playbooks that uses kops to provision Google Cloud

### DIFF
--- a/platforms/gcp/README.md
+++ b/platforms/gcp/README.md
@@ -1,1 +1,38 @@
-GCP platform specific code and scripts
+# GCP platform specific code and scripts
+## Google Cloud provisioning and setting up Kubernetes cluster using KOPS
+These playbook act as a wrapper class for all the `kops`, `gsutil` & `gcloud` command. 
+
+### Prerequisites
+- kubectl
+- gcloud
+- kops
+
+### Setting up
+
+- Run `glcloud init`, and authenticate into your google account linked with the Google Cloud
+
+### Running
+
+- Run `create-vpc.yml` using anisble-playbook, that will create a Virtual Private Cloud
+```bash
+ansible-playbook create-vpc.yml -vv
+```
+- Run `create-k8s-cluster`, this will create a Bucket with Random name and the cluster with same name with `.k8s.local` added.
+Pass the Project name and Node count
+```bash
+ansible-playbook create-k8s-cluster.yml -vv --extra-vars "PROJECT=openebs-ci NODES=1"
+```
+alas! Cluster is Created!
+
+### Deleting the cluster
+
+- Run `delete-k8s-cluster`, this will delete the cluster as well as the Bucket associated
+Pass the cluster name in `NAME`
+```bash
+ansible-playbook delete-k8s-cluster.yml -vv --extra-vars "NAME=openebs-e2e-zo211u"
+```
+- Run `delete-vpc` to delete the existing VPC (if required)
+```bash
+ansible-playbook delete-vpc.yml -vv
+```
+

--- a/platforms/gcp/create-k8s-cluster.yml
+++ b/platforms/gcp/create-k8s-cluster.yml
@@ -1,0 +1,30 @@
+# Description:  Generates a random name, & creates a bucket, InstanceGroup object and Initializes 
+# VMs running Kubernetes, in accordance to the node_count specified using kops in Google Cloud 
+# Author: Harshvardhan Karn
+###############################################################################################
+#Steps:
+#1. Generate a random 6 digit string using Python script
+#2. Create a bucket with the generated random Name
+#3. Create the Clusters, InstanceGroup objects and state store in bucket
+#4. Create the k8s Cluster, using VM instances.
+#5. Log a file with the name of Cluster inside /temp/run_id/gcp_cluster
+###############################################################################################
+
+---
+- hosts: localhost
+  tasks:
+       - name: Generating Random Cluster Name
+         shell: python3 random_name.py
+         register: cluster_name
+
+       - name: Creating Bucket
+         shell: gsutil mb gs://{{cluster_name.stdout}}/
+
+       - name: Creating the Cluster & InstanceGroup objects in our state store
+         shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops create cluster {{cluster_name.stdout}}.k8s.local --zones us-central1-a --state gs://{{cluster_name.stdout}}/ --project={{PROJECT}} --node-count {{NODES}} --vpc=openebs-e2e
+
+       - name: Creating K8s Cluster
+         shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops update cluster {{cluster_name.stdout}}.k8s.local --state gs://{{cluster_name.stdout}}/ --yes
+
+       - name: Logging Cluster Name inside /temp/run_id/gcp_cluster/
+         shell: mkdir -p ~/temp/123/gcp_cluster && touch ~/temp/123/gcp_cluster/{{cluster_name.stdout}}

--- a/platforms/gcp/create-vpc.yml
+++ b/platforms/gcp/create-vpc.yml
@@ -1,0 +1,14 @@
+# Description:  Creates a Virtual Private Cloud with the name openebs-e2e, that will be specified
+# with all other clusters. Using --subnet-mode=auto will create a subnet for every zone. This file
+# is ran at the begining of e2e tests
+# Author: Harshvardhan Karn
+###############################################################################################
+#Steps:
+#1. Create a VPC, openebs-e2e in Google Cloud
+###############################################################################################
+
+---
+- hosts: localhost
+  tasks:
+       - name: Creating VPC `openebs-e2e`
+         shell: gcloud compute --project=openebs-ci networks create openebs-e2e --subnet-mode=auto

--- a/platforms/gcp/delete-k8s-cluster.yml
+++ b/platforms/gcp/delete-k8s-cluster.yml
@@ -1,0 +1,17 @@
+# Description:  Deletes the Cluster and the Bucket associated the NAME passed as the extra-var
+# in playbook, e.g. --extra-vars="NAME=<cluster-name>" 
+# Author: Harshvardhan Karn
+###############################################################################################
+# Steps:
+# 1. Delete the Cluster
+# 2. Delete the Bucket
+###############################################################################################
+
+---
+- hosts: localhost
+  tasks:
+       - name: Deleting Cluster
+         shell: kops delete cluster --yes --name {{NAME}}.k8s.local --state gs://{{NAME}}/
+       
+       - name: Deleting Bucket
+         shell: gsutil rm -r gs://{{NAME}}/ 

--- a/platforms/gcp/delete-vpc.yml
+++ b/platforms/gcp/delete-vpc.yml
@@ -1,0 +1,13 @@
+# Description:  Deletes the Virtual Private Cloud with the name openebs-e2e, runs when all e2e test
+# are finished running 
+# Author: Harshvardhan Karn
+###############################################################################################
+#Steps:
+#1. Delete the VPC, openebs-e2e in Google Cloud
+###############################################################################################
+
+---
+- hosts: localhost
+  tasks:
+       - name: Deleting VPC `openebs-e2e`
+         shell: gcloud compute --project=openebs-ci networks delete openebs-e2e -q

--- a/platforms/gcp/random_name.py
+++ b/platforms/gcp/random_name.py
@@ -1,0 +1,10 @@
+import string
+import random
+
+# Function id_generator() generates random 6 digit lowercase alphanumeric string
+def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
+    return ''.join(random.choice(chars) for _ in range(size))
+
+if __name__ == "__main__":
+    random=id_generator()
+    print ('openebs-e2e-'+random)

--- a/platforms/gcp/test_random_name.py
+++ b/platforms/gcp/test_random_name.py
@@ -1,0 +1,8 @@
+import random_name
+import unittest
+
+class MyTest(unittest.TestCase):
+    def test_id_generator(self):
+        self.assertEqual(len(random_name.id_generator()), 6)
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Playbooks that provisions the Google Cloud to use VM instances as Kubernetes Cluster
- Creates VPC and then Bucket followed by K8s cluster
- Deletes Bucket and Cluster
- Deletes VPC
- `random_name.py` generates random name that is used as unique name for clusters
- Add for Python script

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>