### PR TITLE
Modify platform/gcp to support logging 

### DIFF
--- a/platforms/gcp/README.md
+++ b/platforms/gcp/README.md
@@ -9,7 +9,7 @@ These playbook act as a wrapper class for all the `kops`, `gsutil` & `gcloud` co
 
 ### Setting up
 
-- Run `glcloud init`, and authenticate into your google account linked with the Google Cloud
+- Run `gcloud init`, and authenticate into your google account linked with the Google Cloud
 
 ### Running
 
@@ -20,9 +20,9 @@ ansible-playbook create-vpc.yml -vv
 - Run `create-k8s-cluster`, this will create a Bucket with Random name and the cluster with same name with `.k8s.local` added.
 Pass the Project name and Node count
 ```bash
-ansible-playbook create-k8s-cluster.yml -vv --extra-vars "PROJECT=openebs-ci NODES=1"
+ansible-playbook create-k8s-cluster.yml -vv --extra-vars "PROJECT=<project-name> NODES=1"
 ```
-alas! Cluster is Created!
+Cluster is Created!
 
 ### Deleting the cluster
 

--- a/platforms/gcp/create-k8s-cluster.yml
+++ b/platforms/gcp/create-k8s-cluster.yml
@@ -12,19 +12,42 @@
 
 ---
 - hosts: localhost
+  vars_files:
+    - gcp-vars.yml
   tasks:
-       - name: Generating Random Cluster Name
-         shell: python3 random_name.py
-         register: cluster_name
-
-       - name: Creating Bucket
-         shell: gsutil mb gs://{{cluster_name.stdout}}/
-
-       - name: Creating the Cluster & InstanceGroup objects in our state store
-         shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops create cluster {{cluster_name.stdout}}.k8s.local --zones us-central1-a --state gs://{{cluster_name.stdout}}/ --project={{PROJECT}} --node-count {{NODES}} --vpc=openebs-e2e
-
-       - name: Creating K8s Cluster
-         shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops update cluster {{cluster_name.stdout}}.k8s.local --state gs://{{cluster_name.stdout}}/ --yes
-
-       - name: Logging Cluster Name inside /temp/run_id/gcp_cluster/
-         shell: mkdir -p ~/temp/123/gcp_cluster && touch ~/temp/123/gcp_cluster/{{cluster_name.stdout}}
+       - block:
+             - name: Generating Random Cluster Name
+               shell: python random_name.py
+               register: cluster_name
+      
+             - name: Creating Bucket
+               shell: gsutil mb gs://{{cluster_name.stdout}}/ >> ~/e2e/GCP/cases/{{ create_cluster_case_id }}/logs
+      
+             - name: Creating the Cluster & InstanceGroup objects in our state store
+               shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops create cluster {{cluster_name.stdout}}.k8s.local --zones us-central1-a --state gs://{{cluster_name.stdout}}/ --project {{PROJECT}} --node-count {{NODES}} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc openebs-e2e >> ~/e2e/GCP/cases/{{ create_cluster_case_id }}/logs
+      
+             - name: Creating K8s Cluster
+               shell: export KOPS_FEATURE_FLAGS=AlphaAllowGCE && kops update cluster {{cluster_name.stdout}}.k8s.local --state gs://{{cluster_name.stdout}}/ --yes >> ~/e2e/GCP/cases/{{ create_cluster_case_id }}/logs
+      
+             - name: Logging Cluster Name inside
+               shell: mkdir -p ~/e2e/GCP/cases/{{ create_cluster_case_id }}/ && touch ~/e2e/GCP/cases/{{ create_cluster_case_id }}/clusters
+               
+             - lineinfile: 
+                 create: yes
+                 state: present
+                 path: '~/e2e/GCP/cases/{{ create_cluster_case_id }}/clusters'
+                 line: '{{ cluster_name.stdout }}'
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+                 status_id: 1
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"
+                 status_id: 5
+       - lineinfile:
+           create: yes
+           state: present
+           path: '~/e2e/GCP/cases/{{ create_cluster_case_id }}/result.json'
+           line: '{ "name" : "Create-cluster", "case_id" : {{ create_cluster_case_id | to_json }}, "suite_id" : {{ gcp_test_suite_id | to_json }}, "status" : {{ flag | to_json }}, "status_id" : {{ status_id | to_json }} }'

--- a/platforms/gcp/create-vpc.yml
+++ b/platforms/gcp/create-vpc.yml
@@ -9,6 +9,24 @@
 
 ---
 - hosts: localhost
+  vars_files:
+    - gcp-vars.yml
   tasks:
-       - name: Creating VPC `openebs-e2e`
-         shell: gcloud compute --project=openebs-ci networks create openebs-e2e --subnet-mode=auto
+       - block:
+             - name: Creating VPC `openebs-e2e`
+               shell: gcloud compute --project=openebs-ci networks create openebs-e2e --subnet-mode=auto > ~/e2e/GCP/cases/{{ create_vpc_case_id }}/logs
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+                 status_id: 1
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"
+                 status_id: 5
+
+       - lineinfile:
+           create: yes
+           state: present
+           path: '~/e2e/GCP/cases/{{ create_vpc_case_id }}/result.json'
+           line: '{ "name" : "create-vpc", "case_id" : {{ create_vpc_case_id | to_json }}, "suite_id" : {{ gcp_test_suite_id | to_json }}, "status" : {{ flag | to_json }}, "status_id" : {{ status_id | to_json }} }'

--- a/platforms/gcp/delete-k8s-cluster.yml
+++ b/platforms/gcp/delete-k8s-cluster.yml
@@ -6,12 +6,41 @@
 # 1. Delete the Cluster
 # 2. Delete the Bucket
 ###############################################################################################
-
 ---
 - hosts: localhost
+  vars_files:
+    - gcp-vars.yml
   tasks:
-       - name: Deleting Cluster
-         shell: kops delete cluster --yes --name {{NAME}}.k8s.local --state gs://{{NAME}}/
-       
-       - name: Deleting Bucket
-         shell: gsutil rm -r gs://{{NAME}}/ 
+       - block:
+             - name: Fetching Cluster Name
+               shell: cat ~/e2e/GCP/cases/{{ create_cluster_case_id }}/clusters
+               register: cluster_name
+
+             - name: Deleting Cluster
+               shell: kops delete cluster --yes --name {{ cluster_name.stdout }}.k8s.local --state gs://{{ cluster_name.stdout }}/ >> ~/e2e/GCP/cases/{{ delete_cluster_case_id }}/logs
+             
+             - name: Deleting Bucket
+               shell: gsutil rm -r gs://{{ cluster_name.stdout }}/ >> ~/e2e/GCP/cases/{{ delete_cluster_case_id }}/logs
+
+             - name: Deleting SSD/Disks
+               shell: gcloud compute disks delete a-etcd-events-{{ cluster_name.stdout }}-k8s-local --zone=us-central1-a -q || gcloud compute disks delete a-etcd-main-{{ cluster_name.stdout }}-k8s-local --zone=us-central1-a -q
+
+             - name: Removing Cluster Name Log
+               shell: rm ~/e2e/GCP/cases/{{ create_cluster_case_id }}/clusters
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+                 status_id: 1
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"
+                 status_id: 5
+
+       - debug:
+           msg: '{{ flag }}'
+       - lineinfile:
+           create: yes
+           state: present
+           path: '~/e2e/GCP/cases/{{ delete_cluster_case_id }}/result.json'
+           line: '{ "name" : "delete-vpc", "case_id" : {{ delete_cluster_case_id | to_json }}, "suite_id" : {{ gcp_test_suite_id | to_json }}, "status" : {{ flag | to_json }}, "status_id" : {{ status_id | to_json }} }'

--- a/platforms/gcp/delete-vpc.yml
+++ b/platforms/gcp/delete-vpc.yml
@@ -8,6 +8,27 @@
 
 ---
 - hosts: localhost
+  vars_files:
+    - gcp-vars.yml
   tasks:
-       - name: Deleting VPC `openebs-e2e`
-         shell: gcloud compute --project=openebs-ci networks delete openebs-e2e -q
+       - block:
+             - block:
+                 - name: Deleting VPC `openebs-e2e`
+                   shell: gcloud compute routes delete $(gcloud compute routes list --filter="name:openebs AND network:openebs-e2e"  --format="get(name)") -q || gcloud compute --project=openebs-ci networks delete openebs-e2e -q >> ~/e2e/GCP/cases/{{ delete_vpc_case_id }}/logs
+               rescue:
+                 - name: Only VPC
+                   shell: gcloud compute --project=openebs-ci networks delete openebs-e2e -q >> ~/e2e/GCP/cases/{{ delete_vpc_case_id }}/>> ~/e2e/GCP/cases/{{ delete_vpc_case_id }}/logs
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+                 status_id: 1
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"
+                 status_id: 5
+       - lineinfile:
+           create: yes
+           state: present
+           path: '~/e2e/GCP/cases/{{ delete_vpc_case_id }}/result.json'
+           line: '{ "name" : "delete-vpc", "case_id" : {{ delete_vpc_case_id | to_json }}, "suite_id" : {{ gcp_test_suite_id | to_json }}, "status" : {{ flag | to_json }}, "status_id" : {{ status_id | to_json }} }'

--- a/platforms/gcp/gcp-vars.yml
+++ b/platforms/gcp/gcp-vars.yml
@@ -1,0 +1,10 @@
+---
+gcp_test_suite_id: 22
+
+create_vpc_case_id: 17
+
+create_cluster_case_id: 15
+ 
+delete_cluster_case_id: 16
+
+delete_vpc_case_id: 18


### PR DESCRIPTION
- Add `lineinfile` Ansible modules to support logging
- Add `Block` and `Rescue` to set flags for test pass/fail
- `gcp-vars.yml` stores `case_id`s and `suite_id`s
- Add a task in the playbook, `delete-k8s-cluster.yml` to delete underlying disks(SSD) associated with the cluster

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>